### PR TITLE
Changed item_drop to add_item for items dropped during transport.

### DIFF
--- a/item_transport.lua
+++ b/item_transport.lua
@@ -249,7 +249,10 @@ luaentity.register_entity("pipeworks:tubed_item", {
 			if not found_next then
 				drop_pos = minetest.find_node_near(vector.add(self.start_pos, velocity), 1, "air")
 				if drop_pos then
-					minetest.item_drop(stack, nil, drop_pos)
+                    -- Using add_item instead of item_drop since this makes pipeworks backward
+                    -- compatible with Minetest 0.4.13.
+                    -- Using item_drop here makes Minetest 0.4.13 crash.
+                    minetest.add_item(drop_pos, stack)
 					self:remove()
 					return
 				end


### PR DESCRIPTION
item_drop makes Minetest 0.4.13 crash, but add_item works in all
versions and the behavior is identical when looking at the blocks.
	modified:   item_transport.lua