### PR TITLE
Fixed settings file leak and invalid io.close

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -16,9 +16,11 @@ pipeworks.modpath = minetest.get_modpath("pipeworks")
 dofile(pipeworks.modpath.."/default_settings.txt")
 
 -- Read the external config file if it exists.
-if io.open(pipeworks.worldpath.."/pipeworks_settings.txt","r") then
-	dofile(pipeworks.worldpath.."/pipeworks_settings.txt")
-	io.close()
+local worldsettingspath = pipeworks.worldpath.."/pipeworks_settings.txt","r"
+local worldsettingsfile = io.open(worldsettingspath)
+if worldsettingsfile then
+	worldsettingsfile:close()
+	dofile(worldsettingspath)
 end
 
 -- Random variables


### PR DESCRIPTION
I believe this is a (very minor) bug in the code for checking for and running a world-specific settings file.  The Lua manual is somewhat unclear about what happens when you call `io.close()` with no arguments, but I did some research and experimentation and concluded that this is, in fact, a bug.

Before, init.lua called `io.open` on `pipeworks.worldpath..'/pipeworks_settings.txt'` to see if it existed, but did not close the resulting file handle if it was found to exist.  It instead erroneously called `io.close()` with no argument, which does nothing if the default output file is set to `io.stdout`, which it is.

This patch saves result of `io.open` to a local variable.  If that value is not `nil` (i.e. if the world settings file exists), the file handle is passed to `io.close` before calling `dofile`.

Also, this saves `pipeworks.worldpath..'/pipeworks_settings.txt'` to a
local variable `worldsettingspath` to reduce redundancy.