### PR TITLE
Add list rings and enable sorting tube reordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,22 @@
+## Files related to minetest development cycle
+/*.patch
+# GNU Patch reject file
+*.rej
+
+## Editors and Development environments
 *~
+*.swp
+*.bak*
+*.orig
+# Vim
+*.vim
+# Kate
+.*.kate-swp
+.swp.*
+# Eclipse (LDT)
+.project
+.settings/
+.buildpath
+.metadata
+# Idea IDE
+.idea/*

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -183,7 +183,14 @@ local function update_meta(meta, enabled)
 			default.gui_bg_img..
 			default.gui_slots..
 			default.get_hotbar_bg(0,7) ..
-			"list[current_player;main;0,7;8,4;]")
+			"list[current_player;main;0,7;8,4;]" ..
+			"listring[current_player;main]"..
+			"listring[context;src]" ..
+			"listring[context;dst]" ..
+			"listring[current_player;main]"..
+			"listring[context;recipe]" ..
+			"listring[context;output]"
+			)
 
 	-- toggling the button doesn't quite call for running a recipe change check
 	-- so instead we run a minimal version for infotext setting only

--- a/filter-injector.lua
+++ b/filter-injector.lua
@@ -45,7 +45,8 @@ local function set_filter_formspec(data, meta)
 				 "Sequence slots Randomly",
 				 "Sequence slots by Rotation"})..
 			exmatch_button..
-			"list[current_player;main;0,4.5;8,4;]"
+			"list[current_player;main;0,4.5;8,4;]" ..
+			"listring[]"
 	end
 	meta:set_string("formspec", formspec)
 end

--- a/sorting_tubes.lua
+++ b/sorting_tubes.lua
@@ -31,7 +31,21 @@ if pipeworks.enable_mese_tube then
 			"image[0,4;1,1;pipeworks_blue.png]"..
 			"image[0,5;1,1;pipeworks_red.png]"..
 			buttons_formspec..
-			"list[current_player;main;0,7;8,4;]")
+			"list[current_player;main;0,7;8,4;]" ..
+			"listring[current_player;main]" ..
+			"listring[current_player;main]" ..
+			"listring[context;line1]" ..
+			"listring[current_player;main]" ..
+			"listring[context;line2]" ..
+			"listring[current_player;main]" ..
+			"listring[context;line3]" ..
+			"listring[current_player;main]" ..
+			"listring[context;line4]" ..
+			"listring[current_player;main]" ..
+			"listring[context;line5]" ..
+			"listring[current_player;main]" ..
+			"listring[context;line6]"
+			)
 	end
 
 	pipeworks.register_tube("pipeworks:mese_tube", {

--- a/sorting_tubes.lua
+++ b/sorting_tubes.lua
@@ -119,8 +119,13 @@ if pipeworks.enable_mese_tube then
 					if not pipeworks.may_configure(pos, player) then return 0 end
 					update_formspec(pos) -- For old tubes
 					local inv = minetest.get_meta(pos):get_inventory()
-					inv:set_stack(from_list, from_index, ItemStack(""))
-					return 0
+
+					if from_list:match("line%d") and to_list:match("line%d") then
+						return count
+					else
+						inv:set_stack(from_list, from_index, ItemStack(""))
+						return 0
+					end
 				end,
 			},
 	})

--- a/trashcan.lua
+++ b/trashcan.lua
@@ -28,7 +28,8 @@ minetest.register_node("pipeworks:trashcan", {
 				default.gui_bg_img..
 				default.gui_slots..
 				default.get_hotbar_bg(0,3) ..
-				"list[current_player;main;0,3;8,4;]")
+				"list[current_player;main;0,3;8,4;]" ..
+				"listring[]")
 		meta:set_string("infotext", "Trash Can")
 		meta:get_inventory():set_size("trash", 1)
 	end, 

--- a/wielder.lua
+++ b/wielder.lua
@@ -14,7 +14,8 @@ local function set_wielder_formspec(data, meta)
 			"item_image[0,0;1,1;"..data.name_base.."_off]"..
 			"label[1,0;"..minetest.formspec_escape(data.description).."]"..
 			"list[current_name;"..minetest.formspec_escape(data.wield_inv_name)..";"..((8-data.wield_inv_width)*0.5)..",1;"..data.wield_inv_width..","..data.wield_inv_height..";]"..
-			"list[current_player;main;0,"..(2+data.wield_inv_height)..";8,4;]")
+			"list[current_player;main;0,"..(2+data.wield_inv_height)..";8,4;]" ..
+			"listring[]")
 	meta:set_string("infotext", data.description)
 end
 


### PR DESCRIPTION
List rings allow shift-click removal of virtual items in sorting tubes and autocrafter output list.
Shift-clicking virtual craftrecipe items switches the autocrafter to craft these.
Shift-click items while the trash formspec is open allows easy and fast item deletion from the inventory.
Behaving as expected in all other cases, too.