### PR TITLE
Enhance params to can_remove and remove_item

### DIFF
--- a/filter-injector.lua
+++ b/filter-injector.lua
@@ -115,7 +115,7 @@ local function grabAndFire(data,slotseq_mode,exmatch_mode,filtmeta,frominv,fromi
 			local stack = frominv:get_stack(frominvname, spos)
 			local doRemove = stack:get_count()
 			if fromtube.can_remove then
-				doRemove = fromtube.can_remove(frompos, fromnode, stack, dir)
+				doRemove = fromtube.can_remove(frompos, fromnode, stack, dir, frominvname, spos)
 			elseif fromdef.allow_metadata_inventory_take then
 				doRemove = fromdef.allow_metadata_inventory_take(frompos, frominvname,spos, stack, fakePlayer)
 			end
@@ -146,7 +146,7 @@ local function grabAndFire(data,slotseq_mode,exmatch_mode,filtmeta,frominv,fromi
 				end
 				if fromtube.remove_items then
 					-- it could be the entire stack...
-					item = fromtube.remove_items(frompos, fromnode, stack, dir, count)
+					item = fromtube.remove_items(frompos, fromnode, stack, dir, count, frominvname, spos)
 				else
 					item = stack:take_item(count)
 					frominv:set_stack(frominvname, spos, stack)


### PR DESCRIPTION
By passing the list name and the slot index, these functions now receive
all data related to removal of an item from an inventory: the side on
which the removal is taking place, as well as which stack is being
pulled from. This means it’s no longer necessary to choose between
implementing `on_metadata_inventory_take` (which tells you which item
stack was pulled from but not from which side of the node) or
`remove_item` (which tells you which side the filter is on but not which
item stack it wants to take).

Fixes GH-205.